### PR TITLE
Changed double quotes to single quotes for gem name

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The `select2-rails` gem integrates the `Select2` jQuery plugin with the Rails as
 
 Add `select2-rails` to your Gemfile and run `bundle install`:
 
-	gem "select2-rails"
+	gem 'select2-rails'
 
 ### Include select2-rails javascript assets
 


### PR DESCRIPTION
Double quotes should only be used when string interpolation is used, when not please use single quotes
